### PR TITLE
enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+os:
+  - linux
+  - osx
+compiler:
+  - clang
+notifications:
+  email: false
+env:
+  matrix:
+    - JULIAVERSION="juliareleases"
+    - JULIAVERSION="julianightlies"
+before_install:
+  - curl http://julialang.org/install-julia.sh | sh -s $JULIAVERSION
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+script:
+  - julia --check-bounds=yes -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd()); Pkg.test("SpecialFunctions")'


### PR DESCRIPTION
You'll need to turn it on at travis-ci.org. The tests appear to be failing on 0.3.3, I'm not sure whether that's expected. They pass on nightly at least.

```
INFO: Testing SpecialFunctions
ERROR: `ZBKNU` has no method matching ZBKNU(::Float64, ::Float64, ::Float64, ::Int32, ::Int32, ::Array{Float64,1}, ::Array{Float64,1}, ::Int64, ::Float64, ::Float64, ::Float64)
 in ZBESH at /home/travis/.julia/v0.3/SpecialFunctions/test/../src/amos/zbesh.jl:137
 in _besselh at /home/travis/.julia/v0.3/SpecialFunctions/test/../src/SpecialFunctions.jl:136
 in besselh at /home/travis/.julia/v0.3/SpecialFunctions/test/../src/SpecialFunctions.jl:190
 in besselh at /home/travis/.julia/v0.3/SpecialFunctions/test/../src/SpecialFunctions.jl:264
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
 in include at ./boot.jl:245
 in include_from_node1 at loading.jl:128
 in process_options at ./client.jl:285
 in _start at ./client.jl:354
 in _start_3B_1716 at /usr/bin/../lib/x86_64-linux-gnu/julia/sys.so
while loading /home/travis/.julia/v0.3/SpecialFunctions/test/bessel.jl, in expression starting on line 16
while loading /home/travis/.julia/v0.3/SpecialFunctions/test/runtests.jl, in expression starting on line 5
```

Also probably want to add a LICENSE.md and eventually a readme to add the status badges to. This will only run on linux unless you request for Travis to turn on multi-os support, which probably isn't necessary here. They're also not accepting new repositories at the moment. http://docs.travis-ci.com/user/multi-os/
Figured I'd leave in the multi-os bits anyway in case this gets bigger and you want to turn it on in the future.
