### PR TITLE
Added MIT LICENSE and copyright header.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (c) 2014-2020 Mike Nolta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ SpecialFunctions.jl
 | hankelh1x   |  |
 | hankelh2    |  |
 | hankelh2x   |  |
+
+
+This file is a part of SpecialFunctions.jl from Mike Nolta.
+License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md

--- a/src/SpecialFunctions.jl
+++ b/src/SpecialFunctions.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 module SpecialFunctions
 
 export  

--- a/src/amos/Amos.jl
+++ b/src/amos/Amos.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 module Amos
 
 const int = Int

--- a/src/amos/dgamln.f
+++ b/src/amos/dgamln.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       DOUBLE PRECISION FUNCTION DGAMLN(Z,IERR)
 C***BEGIN PROLOGUE  DGAMLN
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/dgamln.jl
+++ b/src/amos/dgamln.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _DGAMLN_GLN = Array(Float64,100)
 const _DGAMLN_CF = Array(Float64,22)
 function DGAMLN(Z::Float64,IERR::Int32)

--- a/src/amos/pass0.sh
+++ b/src/amos/pass0.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 for IFN in $(ls *.f); do
     OFN=${IFN%.*}.jl0
 

--- a/src/amos/pass1.jl
+++ b/src/amos/pass1.jl
@@ -1,5 +1,8 @@
 #!/usr/bin/env julia
 
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 using Base.Meta.isexpr
 
 iscall(e::Expr, name::Symbol) = isexpr(e,:call) && e.args[1] == name

--- a/src/amos/zabs.f
+++ b/src/amos/zabs.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       DOUBLE PRECISION FUNCTION ZABS(ZR, ZI)
 C***BEGIN PROLOGUE  ZABS
 C***REFER TO  ZBESH,ZBESI,ZBESJ,ZBESK,ZBESY,ZAIRY,ZBIRY

--- a/src/amos/zabs.jl
+++ b/src/amos/zabs.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZABS(Z::Complex128)
     __ZABS__::Float64 = zero(Float64)
     Q::Float64 = zero(Float64)

--- a/src/amos/zacai.f
+++ b/src/amos/zacai.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZACAI(ZR, ZI, FNU, KODE, MR, N, YR, YI, NZ, RL, TOL,
      * ELIM, ALIM)
 C***BEGIN PROLOGUE  ZACAI

--- a/src/amos/zacai.jl
+++ b/src/amos/zacai.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZACAI_CYR = Array(Float64,2)
 const _ZACAI_CYI = Array(Float64,2)
 function ZACAI(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,MR::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,RL::Float64,TOL::Float64,ELIM::Float64,ALIM::Float64)

--- a/src/amos/zacon.f
+++ b/src/amos/zacon.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZACON(ZR, ZI, FNU, KODE, MR, N, YR, YI, NZ, RL, FNUL,
      * TOL, ELIM, ALIM)
 C***BEGIN PROLOGUE  ZACON

--- a/src/amos/zacon.jl
+++ b/src/amos/zacon.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZACON_CYR = Array(Float64,2)
 const _ZACON_CYI = Array(Float64,2)
 const _ZACON_CSSR = Array(Float64,3)

--- a/src/amos/zairy.f
+++ b/src/amos/zairy.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZAIRY(ZR, ZI, ID, KODE, AIR, AII, NZ, IERR)
 C***BEGIN PROLOGUE  ZAIRY
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/zairy.jl
+++ b/src/amos/zairy.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZAIRY_CYR = Array(Float64,1)
 const _ZAIRY_CYI = Array(Float64,1)
 function ZAIRY(ZR::Float64,ZI::Float64,ID::Int32,KODE::Int32,AIR::Float64,AII::Float64,NZ::Int32,IERR::Int32)

--- a/src/amos/zasyi.f
+++ b/src/amos/zasyi.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZASYI(ZR, ZI, FNU, KODE, N, YR, YI, NZ, RL, TOL, ELIM,
      * ALIM)
 C***BEGIN PROLOGUE  ZASYI

--- a/src/amos/zasyi.jl
+++ b/src/amos/zasyi.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZASYI(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,RL::Float64,TOL::Float64,ELIM::Float64,ALIM::Float64)
     AA::Float64 = zero(Float64)
     AEZ::Float64 = zero(Float64)

--- a/src/amos/zbesh.f
+++ b/src/amos/zbesh.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBESH(ZR, ZI, FNU, KODE, M, N, CYR, CYI, NZ, IERR)
 C***BEGIN PROLOGUE  ZBESH
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/zbesh.jl
+++ b/src/amos/zbesh.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZBESH(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,M::Int32,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},NZ::Int32,IERR::Int32)
     AA::Float64 = zero(Float64)
     ALIM::Float64 = zero(Float64)

--- a/src/amos/zbesi.f
+++ b/src/amos/zbesi.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBESI(ZR, ZI, FNU, KODE, N, CYR, CYI, NZ, IERR)
 C***BEGIN PROLOGUE  ZBESI
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/zbesi.jl
+++ b/src/amos/zbesi.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZBESI(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},NZ::Int32,IERR::Int32)
     AA::Float64 = zero(Float64)
     ALIM::Float64 = zero(Float64)

--- a/src/amos/zbesj.f
+++ b/src/amos/zbesj.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBESJ(ZR, ZI, FNU, KODE, N, CYR, CYI, NZ, IERR)
 C***BEGIN PROLOGUE  ZBESJ
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/zbesj.jl
+++ b/src/amos/zbesj.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZBESJ(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},NZ::Int32,IERR::Int32)
     AA::Float64 = zero(Float64)
     ALIM::Float64 = zero(Float64)

--- a/src/amos/zbesk.f
+++ b/src/amos/zbesk.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBESK(ZR, ZI, FNU, KODE, N, CYR, CYI, NZ, IERR)
 C***BEGIN PROLOGUE  ZBESK
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/zbesk.jl
+++ b/src/amos/zbesk.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZBESK(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},NZ::Int32,IERR::Int32)
     AA::Float64 = zero(Float64)
     ALIM::Float64 = zero(Float64)

--- a/src/amos/zbesy.f
+++ b/src/amos/zbesy.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBESY(ZR, ZI, FNU, KODE, N, CYR, CYI, NZ, CWRKR, CWRKI,
      *                 IERR)
 C***BEGIN PROLOGUE  ZBESY

--- a/src/amos/zbesy.jl
+++ b/src/amos/zbesy.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZBESY(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},NZ::Int32,CWRKR::AbstractArray{Float64},CWRKI::AbstractArray{Float64},IERR::Int32)
     AA::Float64 = zero(Float64)
     ASCLE::Float64 = zero(Float64)

--- a/src/amos/zbinu.f
+++ b/src/amos/zbinu.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBINU(ZR, ZI, FNU, KODE, N, CYR, CYI, NZ, RL, FNUL,
      * TOL, ELIM, ALIM)
 C***BEGIN PROLOGUE  ZBINU

--- a/src/amos/zbinu.jl
+++ b/src/amos/zbinu.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZBINU_CWR = Array(Float64,2)
 const _ZBINU_CWI = Array(Float64,2)
 function ZBINU(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},NZ::Int32,RL::Float64,FNUL::Float64,TOL::Float64,ELIM::Float64,ALIM::Float64)

--- a/src/amos/zbiry.f
+++ b/src/amos/zbiry.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBIRY(ZR, ZI, ID, KODE, BIR, BII, IERR)
 C***BEGIN PROLOGUE  ZBIRY
 C***DATE WRITTEN   830501   (YYMMDD)

--- a/src/amos/zbiry.jl
+++ b/src/amos/zbiry.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZBIRY_CYR = Array(Float64,2)
 const _ZBIRY_CYI = Array(Float64,2)
 function ZBIRY(ZR::Float64,ZI::Float64,ID::Int32,KODE::Int32,BIR::Float64,BII::Float64,IERR::Int32)

--- a/src/amos/zbknu.f
+++ b/src/amos/zbknu.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBKNU(ZR, ZI, FNU, KODE, N, YR, YI, NZ, TOL, ELIM,
      * ALIM)
 C***BEGIN PROLOGUE  ZBKNU

--- a/src/amos/zbknu.jl
+++ b/src/amos/zbknu.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZBKNU_CYR = Array(Float64,2)
 const _ZBKNU_CYI = Array(Float64,2)
 const _ZBKNU_CSSR = Array(Float64,3)

--- a/src/amos/zbuni.f
+++ b/src/amos/zbuni.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBUNI(ZR, ZI, FNU, KODE, N, YR, YI, NZ, NUI, NLAST,
      * FNUL, TOL, ELIM, ALIM)
 C***BEGIN PROLOGUE  ZBUNI

--- a/src/amos/zbuni.jl
+++ b/src/amos/zbuni.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZBUNI_CYR = Array(Float64,2)
 const _ZBUNI_CYI = Array(Float64,2)
 const _ZBUNI_BRY = Array(Float64,3)

--- a/src/amos/zbunk.f
+++ b/src/amos/zbunk.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZBUNK(ZR, ZI, FNU, KODE, MR, N, YR, YI, NZ, TOL, ELIM,
      * ALIM)
 C***BEGIN PROLOGUE  ZBUNK

--- a/src/amos/zbunk.jl
+++ b/src/amos/zbunk.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZBUNK(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,MR::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,TOL::Float64,ELIM::Float64,ALIM::Float64)
     AX::Float64 = zero(Float64)
     AY::Float64 = zero(Float64)

--- a/src/amos/zdiv.f
+++ b/src/amos/zdiv.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZDIV(AR, AI, BR, BI, CR, CI)
 C***BEGIN PROLOGUE  ZDIV
 C***REFER TO  ZBESH,ZBESI,ZBESJ,ZBESK,ZBESY,ZAIRY,ZBIRY

--- a/src/amos/zdiv.jl
+++ b/src/amos/zdiv.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZDIV(AR::Float64,AI::Float64,BR::Float64,BI::Float64,CR::Float64,CI::Float64)
     BM::Float64 = zero(Float64)
     CA::Float64 = zero(Float64)

--- a/src/amos/zexp.f
+++ b/src/amos/zexp.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZEXP(AR, AI, BR, BI)
 C***BEGIN PROLOGUE  ZEXP
 C***REFER TO  ZBESH,ZBESI,ZBESJ,ZBESK,ZBESY,ZAIRY,ZBIRY

--- a/src/amos/zexp.jl
+++ b/src/amos/zexp.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZEXP(AR::Float64,AI::Float64,BR::Float64,BI::Float64)
     CA::Float64 = zero(Float64)
     CB::Float64 = zero(Float64)

--- a/src/amos/zkscl.f
+++ b/src/amos/zkscl.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZKSCL(ZRR,ZRI,FNU,N,YR,YI,NZ,RZR,RZI,ASCLE,TOL,ELIM)
 C***BEGIN PROLOGUE  ZKSCL
 C***REFER TO  ZBESK

--- a/src/amos/zkscl.jl
+++ b/src/amos/zkscl.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZKSCL_CYR = Array(Float64,2)
 const _ZKSCL_CYI = Array(Float64,2)
 function ZKSCL(ZRR::Float64,ZRI::Float64,FNU::Float64,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,RZR::Float64,RZI::Float64,ASCLE::Float64,TOL::Float64,ELIM::Float64)

--- a/src/amos/zlog.f
+++ b/src/amos/zlog.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZLOG(AR, AI, BR, BI, IERR)
 C***BEGIN PROLOGUE  ZLOG
 C***REFER TO  ZBESH,ZBESI,ZBESJ,ZBESK,ZBESY,ZAIRY,ZBIRY

--- a/src/amos/zlog.jl
+++ b/src/amos/zlog.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZLOG(AR::Float64,AI::Float64,BR::Float64,BI::Float64,IERR::Int32)
     DHPI::Float64 = zero(Float64)
     DPI::Float64 = zero(Float64)

--- a/src/amos/zmlri.f
+++ b/src/amos/zmlri.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZMLRI(ZR, ZI, FNU, KODE, N, YR, YI, NZ, TOL)
 C***BEGIN PROLOGUE  ZMLRI
 C***REFER TO  ZBESI,ZBESK

--- a/src/amos/zmlri.jl
+++ b/src/amos/zmlri.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZMLRI(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,TOL::Float64)
     ACK::Float64 = zero(Float64)
     AK::Float64 = zero(Float64)

--- a/src/amos/zmlt.f
+++ b/src/amos/zmlt.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZMLT(AR, AI, BR, BI, CR, CI)
 C***BEGIN PROLOGUE  ZMLT
 C***REFER TO  ZBESH,ZBESI,ZBESJ,ZBESK,ZBESY,ZAIRY,ZBIRY

--- a/src/amos/zmlt.jl
+++ b/src/amos/zmlt.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZMLT(AR::Float64,AI::Float64,BR::Float64,BI::Float64,CR::Float64,CI::Float64)
     CA::Float64 = zero(Float64)
     CB::Float64 = zero(Float64)

--- a/src/amos/zrati.f
+++ b/src/amos/zrati.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZRATI(ZR, ZI, FNU, N, CYR, CYI, TOL)
 C***BEGIN PROLOGUE  ZRATI
 C***REFER TO  ZBESI,ZBESK,ZBESH

--- a/src/amos/zrati.jl
+++ b/src/amos/zrati.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZRATI(ZR::Float64,ZI::Float64,FNU::Float64,N::Int32,CYR::AbstractArray{Float64},CYI::AbstractArray{Float64},TOL::Float64)
     AK::Float64 = zero(Float64)
     AMAGZ::Float64 = zero(Float64)

--- a/src/amos/zs1s2.f
+++ b/src/amos/zs1s2.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZS1S2(ZRR, ZRI, S1R, S1I, S2R, S2I, NZ, ASCLE, ALIM,
      * IUF)
 C***BEGIN PROLOGUE  ZS1S2

--- a/src/amos/zs1s2.jl
+++ b/src/amos/zs1s2.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZS1S2(ZRR::Float64,ZRI::Float64,S1R::Float64,S1I::Float64,S2R::Float64,S2I::Float64,NZ::Int32,ASCLE::Float64,ALIM::Float64,IUF::Int32)
     AA::Float64 = zero(Float64)
     ALN::Float64 = zero(Float64)

--- a/src/amos/zseri.f
+++ b/src/amos/zseri.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZSERI(ZR, ZI, FNU, KODE, N, YR, YI, NZ, TOL, ELIM,
      * ALIM)
 C***BEGIN PROLOGUE  ZSERI

--- a/src/amos/zseri.jl
+++ b/src/amos/zseri.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZSERI_WR = Array(Float64,2)
 const _ZSERI_WI = Array(Float64,2)
 function ZSERI(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,TOL::Float64,ELIM::Float64,ALIM::Float64)

--- a/src/amos/zshch.f
+++ b/src/amos/zshch.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZSHCH(ZR, ZI, CSHR, CSHI, CCHR, CCHI)
 C***BEGIN PROLOGUE  ZSHCH
 C***REFER TO  ZBESK,ZBESH

--- a/src/amos/zshch.jl
+++ b/src/amos/zshch.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZSHCH(ZR::Float64,ZI::Float64,CSHR::Float64,CSHI::Float64,CCHR::Float64,CCHI::Float64)
     CH::Float64 = zero(Float64)
     CN::Float64 = zero(Float64)

--- a/src/amos/zsqrt.f
+++ b/src/amos/zsqrt.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZSQRT(AR, AI, BR, BI)
 C***BEGIN PROLOGUE  ZSQRT
 C***REFER TO  ZBESH,ZBESI,ZBESJ,ZBESK,ZBESY,ZAIRY,ZBIRY

--- a/src/amos/zsqrt.jl
+++ b/src/amos/zsqrt.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZSQRT(AR::Float64,AI::Float64,BR::Float64,BI::Float64)
     DPI::Float64 = zero(Float64)
     DRT::Float64 = zero(Float64)

--- a/src/amos/zuchk.f
+++ b/src/amos/zuchk.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUCHK(YR, YI, NZ, ASCLE, TOL)
 C***BEGIN PROLOGUE  ZUCHK
 C***REFER TO ZSERI,ZUOIK,ZUNK1,ZUNK2,ZUNI1,ZUNI2,ZKSCL

--- a/src/amos/zuchk.jl
+++ b/src/amos/zuchk.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZUCHK(YR::Float64,YI::Float64,NZ::Int32,ASCLE::Float64,TOL::Float64)
     SS::Float64 = zero(Float64)
     ST::Float64 = zero(Float64)

--- a/src/amos/zunhj.f
+++ b/src/amos/zunhj.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUNHJ(ZR, ZI, FNU, IPMTR, TOL, PHIR, PHII, ARGR, ARGI,
      * ZETA1R, ZETA1I, ZETA2R, ZETA2I, ASUMR, ASUMI, BSUMR, BSUMI)
 C***BEGIN PROLOGUE  ZUNHJ

--- a/src/amos/zunhj.jl
+++ b/src/amos/zunhj.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUNHJ_UPR = Array(Float64,14)
 const _ZUNHJ_UPI = Array(Float64,14)
 const _ZUNHJ_PR = Array(Float64,30)

--- a/src/amos/zuni1.f
+++ b/src/amos/zuni1.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUNI1(ZR, ZI, FNU, KODE, N, YR, YI, NZ, NLAST, FNUL,
      * TOL, ELIM, ALIM)
 C***BEGIN PROLOGUE  ZUNI1

--- a/src/amos/zuni1.jl
+++ b/src/amos/zuni1.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUNI1_CYR = Array(Float64,2)
 const _ZUNI1_CYI = Array(Float64,2)
 const _ZUNI1_CWRKR = Array(Float64,16)

--- a/src/amos/zuni2.f
+++ b/src/amos/zuni2.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUNI2(ZR, ZI, FNU, KODE, N, YR, YI, NZ, NLAST, FNUL,
      * TOL, ELIM, ALIM)
 C***BEGIN PROLOGUE  ZUNI2

--- a/src/amos/zuni2.jl
+++ b/src/amos/zuni2.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUNI2_CYR = Array(Float64,2)
 const _ZUNI2_CYI = Array(Float64,2)
 const _ZUNI2_CSSR = Array(Float64,3)

--- a/src/amos/zunik.f
+++ b/src/amos/zunik.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUNIK(ZRR, ZRI, FNU, IKFLG, IPMTR, TOL, INIT, PHIR,
      * PHII, ZETA1R, ZETA1I, ZETA2R, ZETA2I, SUMR, SUMI, CWRKR, CWRKI)
 C***BEGIN PROLOGUE  ZUNIK

--- a/src/amos/zunik.jl
+++ b/src/amos/zunik.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUNIK_CON = Array(Float64,2)
 const _ZUNIK_C = Array(Float64,120)
 function ZUNIK(ZRR::Float64,ZRI::Float64,FNU::Float64,IKFLG::Int32,IPMTR::Int32,TOL::Float64,INIT::Int32,PHIR::Float64,PHII::Float64,ZETA1R::Float64,ZETA1I::Float64,ZETA2R::Float64,ZETA2I::Float64,SUMR::Float64,SUMI::Float64,CWRKR::AbstractArray{Float64},CWRKI::AbstractArray{Float64})

--- a/src/amos/zunk1.f
+++ b/src/amos/zunk1.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUNK1(ZR, ZI, FNU, KODE, MR, N, YR, YI, NZ, TOL, ELIM,
      * ALIM)
 C***BEGIN PROLOGUE  ZUNK1

--- a/src/amos/zunk1.jl
+++ b/src/amos/zunk1.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUNK1_ZETA2R = Array(Float64,2)
 const _ZUNK1_ZETA2I = Array(Float64,2)
 const _ZUNK1_ZETA1R = Array(Float64,2)

--- a/src/amos/zunk2.f
+++ b/src/amos/zunk2.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUNK2(ZR, ZI, FNU, KODE, MR, N, YR, YI, NZ, TOL, ELIM,
      * ALIM)
 C***BEGIN PROLOGUE  ZUNK2

--- a/src/amos/zunk2.jl
+++ b/src/amos/zunk2.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUNK2_ZETA2R = Array(Float64,2)
 const _ZUNK2_ZETA2I = Array(Float64,2)
 const _ZUNK2_ZETA1R = Array(Float64,2)

--- a/src/amos/zuoik.f
+++ b/src/amos/zuoik.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZUOIK(ZR, ZI, FNU, KODE, IKFLG, N, YR, YI, NUF, TOL,
      * ELIM, ALIM)
 C***BEGIN PROLOGUE  ZUOIK

--- a/src/amos/zuoik.jl
+++ b/src/amos/zuoik.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 const _ZUOIK_CWRKR = Array(Float64,16)
 const _ZUOIK_CWRKI = Array(Float64,16)
 function ZUOIK(ZR::Float64,ZI::Float64,FNU::Float64,KODE::Int32,IKFLG::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NUF::Int32,TOL::Float64,ELIM::Float64,ALIM::Float64)

--- a/src/amos/zwrsk.f
+++ b/src/amos/zwrsk.f
@@ -1,3 +1,6 @@
+C This file is a part of SpecialFunctions.jl from Mike Nolta.
+C License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
       SUBROUTINE ZWRSK(ZRR, ZRI, FNU, KODE, N, YR, YI, NZ, CWR, CWI,
      * TOL, ELIM, ALIM)
 C***BEGIN PROLOGUE  ZWRSK

--- a/src/amos/zwrsk.jl
+++ b/src/amos/zwrsk.jl
@@ -1,3 +1,6 @@
+# This file is a part of SpecialFunctions.jl from Mike Nolta.
+# License is MIT: https://github.com/nolta/SpecialFunctions.jl/LICENSE.md
+
 function ZWRSK(ZRR::Float64,ZRI::Float64,FNU::Float64,KODE::Int32,N::Int32,YR::AbstractArray{Float64},YI::AbstractArray{Float64},NZ::Int32,CWR::AbstractArray{Float64},CWI::AbstractArray{Float64},TOL::Float64,ELIM::Float64,ALIM::Float64)
     ACT::Float64 = zero(Float64)
     ACW::Float64 = zero(Float64)


### PR DESCRIPTION
Closes nolta/SpecialFunctions.jl#3

As I commented [here](https://github.com/nolta/SpecialFunctions.jl/issues/3), this pull request add a MIT `LICENSE.md` file and license headers to the corresponding files.